### PR TITLE
Add Omni-Rewriter to Related Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ Key trends:
 |------|--------------|------|
 | **TubePrompter** | Converts existing videos into optimized text-to-video prompts for Sora, Veo, Runway, etc. | [tubeprompter.com](https://tubeprompter.com/) |
 | **Vadoo AI** | AI shorts automation platform for faceless channels and social clips. | [vadoo.tv](https://vadoo.tv/) |
+| **Omni-Rewriter** | Open agentic prompt-expansion harness for image/video model dialects (schema + validation + bounded repair; expand ≠ generate). | [github.com/WayneJin0918/Omni-Rewriter](https://github.com/WayneJin0918/Omni-Rewriter) |
 
 ---
 


### PR DESCRIPTION
## Summary
Add [Omni-Rewriter](https://github.com/WayneJin0918/Omni-Rewriter) — an open agentic **prompt-expansion harness** for image/video generation.

- Schema → Writer LM draft → deterministic validation → bounded repair → dialect render
- Profiles include H3 / Seedance / Seedream / Qwen-Image
- Explicitly separates **expand ≠ generate**
- Apache-2.0 · Demo: https://waynejin0918.github.io/Omni-Rewriter/

## Notes
Happy to adjust section placement or wording if needed. Thanks for maintaining this list!

Made with [Cursor](https://cursor.com)